### PR TITLE
Test for odd quantity BuyXGetYTest

### DIFF
--- a/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
@@ -66,6 +66,20 @@ class BuyXGetYTest extends TestCase
                 'maxRewardQty' => 5,
                 'expected' => 5,
             ],
+            [
+                'linesQuantity' => 3,
+                'minQty' => 2,
+                'rewardQty' => 1,
+                'maxRewardQty' => 2,
+                'expected' => 1,
+            ],
+            [
+                'linesQuantity' => 7,
+                'minQty' => 2,
+                'rewardQty' => 1,
+                'maxRewardQty' => 10,
+                'expected' => 3,
+            ],
         ];
 
         foreach ($checks as $check) {


### PR DESCRIPTION
getRewardQuantity() should return `int`, but returns a `double` when the quantity is an odd amount. Test should probably be more extensive, but this should "raise" the issue.

TODO throws expected int got double
```php

            $lineDiscountTotal = $unitPrice * $qtyToAllocate; // becomes Double
            $discountTotal += $lineDiscountTotal;

            $rewardLine->discountTotal = new Price(
                $lineDiscountTotal,
                $cart->currency,
                (int) 1
            );
```

Not sure if relevant but: 
```
PHP 8.1.21 (cli) (built: Jul  8 2023 07:09:57) (NTS)
lunarphp/lunar 0.5.0 Lunar Monorepo
```